### PR TITLE
Add a metainfo file for release information

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -3,11 +3,13 @@ fwupd-efi Release Notes
 Write release entries:
 
 git log --format="%s" --cherry-pick --right-only 1.0... | grep -i -v trivial | grep -v Merge | sort | uniq
+Add any user visible changes into ../contrib/org.freedesktop.fwupd.efi.metainfo.xml
+appstream-util appdata-to-news ../contrib/org.freedesktop.fwupd.efi.metainfo.xml > NEWS
 
 2. Commit changes to git:
 
 # MAKE SURE THIS IS CORRECT
-export release_ver="1.1"
+export release_ver="1.0"
 
 git commit -a -m "Release fwupd-efi ${release_ver}"
 git tag -s -f -m "Release fwupd-efi ${release_ver}" "${release_ver}"

--- a/contrib/org.freedesktop.fwupd.efi.metainfo.xml
+++ b/contrib/org.freedesktop.fwupd.efi.metainfo.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2021 Richard Hughes <richard@hughsie.com> -->
+<component type="generic">
+  <id>org.freedesktop.fwupd.efi</id>
+  <extends>org.freedesktop.fwupd</extends>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.0+</project_license>
+  <name>fwupd-efi</name>
+  <summary>EFI helpers to install system firmware</summary>
+  <description>
+    <p>
+      This project builds a UEFI binary for installing updates using the
+      UpdateCapsule runtime service.
+    </p>
+    <p>
+      The source was imported from the combined fwupd project, and is now
+      maintained separately to allow fwupd userspace releases and fwupd-efi
+      UEFI executable releases to follow a different candence.
+    </p>
+  </description>
+  <url type="bugtracker">https://github.com/fwupd/fwupd-efi/issues</url>
+  <url type="homepage">https://fwupd.org/</url>
+  <update_contact>richard_at_hughsie.com</update_contact>
+  <content_rating type="oars-1.0"/>
+  <releases>
+    <release version="1.0" date="2021-04-23">
+      <description>
+        <p>This is the first release split from the fwupd parent project.</p>
+      </description>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
If this looks okay, lets merge and then tag and upload 1.0 and do the fwupd side. I'd like to get fwupd 1.6.0 out before the end of next week and I think 1.6.0 is the perfect time to make this split.