### PR TITLE
Fix a regression when applying updates on an HP M60

### DIFF
--- a/efi/fwupdate.c
+++ b/efi/fwupdate.c
@@ -454,12 +454,16 @@ fwup_apply_capsules(EFI_CAPSULE_HEADER **capsules,
 
 	rc = uefi_call_wrapper(RT->QueryCapsuleCapabilities, 4, capsules,
 				num_updates, &max_capsule_size, reset);
-	if (EFI_ERROR(rc)) {
-		fwup_warning(L"Could not query capsule capabilities: %r", rc);
-		return rc;
+	if (rc == EFI_SUCCESS) {
+		fwup_debug(L"QueryCapsuleCapabilities: %r max: %ld reset:%d",
+			   rc,
+			   max_capsule_size,
+			   *reset);
+	} else {
+		fwup_warning(L"QueryCapsuleCapabilities failed, assuming EfiResetWarm: %r", rc);
+		*reset = EfiResetWarm;
 	}
-	fwup_debug(L"QueryCapsuleCapabilities: %r max: %ld reset:%d",
-	           rc, max_capsule_size, *reset);
+
 	fwup_debug(L"Capsules: %d", num_updates);
 
 	fwup_msleep(1 * SECONDS);


### PR DESCRIPTION
Do not fail for any systems that return EFI_UNSUPPORTED from RT->QueryCapsuleCapabilities().