### PR TITLE
Show the version when starting fwupd-efi

### DIFF
--- a/efi/fwupdate.c
+++ b/efi/fwupdate.c
@@ -4,13 +4,15 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
+#include "config.h"
+
 #include <efi.h>
 #include <efilib.h>
 
 #include "fwup-cleanups.h"
 #include "fwup-common.h"
-#include "fwup-efi.h"
 #include "fwup-debug.h"
+#include "fwup-efi.h"
 
 #define UNUSED __attribute__((__unused__))
 #define GNVN_BUF_SIZE			1024
@@ -543,6 +545,9 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
 
 	/* if SHIM_DEBUG is set, fwup_info info for our attached debugger */
 	fwup_debug_hook();
+
+	/* show the version to screen */
+	fwup_info(L"fwupd-efi version " PACKAGE_VERSION);
 
 	/* step 1: find and validate update state variables */
 	/* XXX TODO:

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -121,6 +121,7 @@ compile_args = ['-Og',
                 '-Wno-address-of-packed-member',
                 '-grecord-gcc-switches',
                 '-DDEBUGDIR="@0@"'.format(debugdir),
+                '-I.',
                 '-isystem', efi_incdir,
                 '-isystem', join_paths(efi_incdir, gnu_efi_path_arch)]
 if get_option('werror')

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,9 @@ project('fwupd-efi', 'c',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
+conf = configuration_data()
+conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+
 cc = meson.get_compiler('c')
 objcopy = find_program('objcopy')
 
@@ -36,6 +39,11 @@ endif
 if get_option('efi_sbat_distro_id') == ''
     warning('-Defi_sbat_distro_id is unset, see README.md')
 endif
+
+configure_file(
+  output : 'config.h',
+  configuration : conf
+)
 
 pkgg = import('pkgconfig')
 pkgg.generate(


### PR DESCRIPTION
This also allows to search for a predicatable string in fwupd to add a
runtime version.