### PR TITLE
Align sections to 512 bytes

### DIFF
--- a/efi/generate_binary.py
+++ b/efi/generate_binary.py
@@ -30,6 +30,8 @@ def _run_objcopy(args):
         ".rodata",
         "-j",
         ".rel*",
+        "--section-alignment",
+        "512",
         args.infile,
         args.outfile,
     ]


### PR DESCRIPTION
Without specifying an alignment, there are gaps in the section table. When signing fwupdx64.efi for Secure Boot, this results in some firmware rejecting it despite having a valid signature. When inspecting the binary with sbverify, it warns about these gaps:

	$ sbverify --list fwupdx64.efi
	warning: gap in section table:
	    .rela   : 0x0000b400 - 0x0000c400,
	    /4      : 0x0000c470 - 0x0000c670,
	warning: gap in section table:
	    /4      : 0x0000c470 - 0x0000c670,
	    .dynsym : 0x0000c800 - 0x0000cc00,
	gaps in the section table may result in different checksums
	...

After setting the section alignment to 512, the gaps are gone and the signed fwupdx64.efi file passes the Secure Boot check as expected.