### PR TITLE
Use objcopy to build arm/aarch64 binaries if binutils 2.38 or newer

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -150,9 +150,9 @@ efi_ldflags = ['-T',
                '-L', efi_crtdir,
                '-L', efi_libdir,
                join_paths(efi_crtdir, arch_crt)]
-if host_cpu == 'aarch64' or host_cpu == 'arm'
-  # Aarch64 and ARM32 don't have an EFI capable objcopy. Use 'binary'
-  # instead, and add required symbols manually.
+if objcopy_version.version_compare ('< 2.38') and (host_cpu == 'aarch64' or host_cpu == 'arm')
+  # older objcopy for Aarch64 and ARM32 are not EFI capable.
+  # Use 'binary' instead, and add required symbols manually.
   efi_ldflags += ['--defsym=EFI_SUBSYSTEM=0xa']
   efi_format = ['-O', 'binary']
 else

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 
 cc = meson.get_compiler('c')
 objcopy = find_program('objcopy')
+objcopy_version = run_command(objcopy, '--version').stdout().split('\n')[0].split(' ')[-1]
 
 prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))


### PR DESCRIPTION
Fixes: #24

Untested by my side, would appreciate someone to test it before it's merged.