### PR TITLE
Fix a FTBFS on aarch64 (Fixes: #36)

### DIFF
--- a/efi/crt0/meson.build
+++ b/efi/crt0/meson.build
@@ -1,5 +1,5 @@
 o_crt0 = custom_target('efi_crt0',
                        input : arch_crt_source,
                        output : arch_crt,
-                       command : [efi_cc, '-c', '@INPUT@', '-o', '@OUTPUT@']
+                       command : [cc.cmd_array(), '-c', '@INPUT@', '-o', '@OUTPUT@']
                        + compile_args)


### PR DESCRIPTION
Fixes: 2040b81 ("Drop the needless efi-cc and efi-ld parameters")
Signed-off-by: Mario Limonciello <mario.limonciello@amd.com>