### PR TITLE
SBOM fixes

### DIFF
--- a/efi/crt0/crt0-efi-aarch64.S
+++ b/efi/crt0/crt0-efi-aarch64.S
@@ -159,6 +159,19 @@ section_table:
 	.2byte	0		// NumberOfLineNumbers  (0 for executables)
 	.4byte	0x40000040	// Characteristics (section flags)
 #endif
+#ifdef USING_SBOM
+	.ascii	".sbom\0\0\0"
+	.4byte	_sbom_vsize - ImageBase		// VirtualSize
+	.4byte	_sbom - ImageBase	// VirtualAddress
+	.4byte	_sbom_size - ImageBase		// SizeOfRawData
+	.4byte	_sbom - ImageBase	// PointerToRawData
+
+	.4byte	0		// PointerToRelocations (0 for executables)
+	.4byte	0		// PointerToLineNumbers (0 for executables)
+	.2byte	0		// NumberOfRelocations  (0 for executables)
+	.2byte	0		// NumberOfLineNumbers  (0 for executables)
+	.4byte	0x40000040	// Characteristics (section flags)
+#endif
 
 	.text
 	.globl _start

--- a/efi/crt0/crt0-efi-aarch64.S
+++ b/efi/crt0/crt0-efi-aarch64.S
@@ -31,7 +31,7 @@ pe_header:
 	.2byte 	0
 coff_header:
 	.2byte	0xaa64				// AArch64
-	.2byte	5				// nr_sections
+	.2byte	NR_SECTIONS		        // nr_sections
 	.4byte	0 				// TimeDateStamp
 	.4byte	0				// PointerToSymbolTable
 	.4byte	0				// NumberOfSymbols
@@ -146,6 +146,7 @@ section_table:
 	.2byte	0			// NumberOfLineNumbers
 	.4byte	0x40000040		// Characteristics (section flags)
 	
+#ifdef USING_SBAT
 	.ascii	".sbat\0\0\0"
 	.4byte	_sbat_vsize - ImageBase		// VirtualSize
 	.4byte	_sbat - ImageBase	// VirtualAddress
@@ -157,6 +158,7 @@ section_table:
 	.2byte	0		// NumberOfRelocations  (0 for executables)
 	.2byte	0		// NumberOfLineNumbers  (0 for executables)
 	.4byte	0x40000040	// Characteristics (section flags)
+#endif
 
 	.text
 	.globl _start

--- a/efi/crt0/crt0-efi-arm.S
+++ b/efi/crt0/crt0-efi-arm.S
@@ -159,6 +159,19 @@ section_table:
 	.2byte	0			// NumberOfLineNumbers
 	.4byte	0x40000040		// Characteristics (section flags)
 #endif
+#ifdef USING_SBOM
+	.ascii	".sbom\0\0\0"
+	.4byte	_sbom_vsize - ImageBase		// VirtualSize
+	.4byte	_sbom - ImageBase	// VirtualAddress
+	.4byte	_sbom_size - ImageBase		// SizeOfRawData
+	.4byte	_sbom - ImageBase	// PointerToRawData
+
+	.4byte	0		// PointerToRelocations (0 for executables)
+	.4byte	0		// PointerToLineNumbers (0 for executables)
+	.2byte	0		// NumberOfRelocations  (0 for executables)
+	.2byte	0		// NumberOfLineNumbers  (0 for executables)
+	.4byte	0x40000040	// Characteristics (section flags)
+#endif
 
 .balign 256
 .globl	_start

--- a/efi/crt0/crt0-efi-arm.S
+++ b/efi/crt0/crt0-efi-arm.S
@@ -31,7 +31,7 @@ pe_header:
 	.2byte 	0
 coff_header:
 	.2byte	0x1c2				// Mixed ARM/Thumb
-	.2byte	5				// nr_sections
+	.2byte	NR_SECTIONS		        // nr_sections
 	.4byte	0 				// TimeDateStamp
 	.4byte	0				// PointerToSymbolTable
 	.4byte	0				// NumberOfSymbols
@@ -147,7 +147,7 @@ section_table:
 	.2byte	0			// NumberOfRelocations
 	.2byte	0			// NumberOfLineNumbers
 	.4byte	0x40000040		// Characteristics (section flags)
-
+#ifdef USING_SBAT
 	.ascii	".sbat\0\0\0"
 	.4byte	_sbat_vsize - ImageBase			// VirtualSize
 	.4byte	_sbat - ImageBase			// VirtualAddress
@@ -158,6 +158,7 @@ section_table:
 	.2byte	0			// NumberOfRelocations
 	.2byte	0			// NumberOfLineNumbers
 	.4byte	0x40000040		// Characteristics (section flags)
+#endif
 
 .balign 256
 .globl	_start

--- a/efi/lds/elf_aarch64_efi.lds
+++ b/efi/lds/elf_aarch64_efi.lds
@@ -102,6 +102,17 @@ SECTIONS
   } =0
   _sbat_size = _epsbat - _sbat;
   _sbat_vsize = _esbat - _sbat;
+  . = ALIGN(4096);
+  .sbom :
+  {
+    _sbom = .;
+    *(.sbom)
+    _esbom = .;
+    . = ALIGN(4096);
+    _epsbom = .;
+  } =0
+  _sbom_size = _epsbom - _sbom;
+  _sbom_vsize = _esbom - _sbom;
   _image_end = .;
   _alldata_size = _image_end - _reloc;
 

--- a/efi/lds/elf_aarch64_efi.lds
+++ b/efi/lds/elf_aarch64_efi.lds
@@ -40,7 +40,33 @@ SECTIONS
    *(.data.*)
    *(.got.plt)
    *(.got)
-
+   
+   /*
+    * Note that these aren't the using the GNU "CONSTRUCTOR" output section
+    * command, so they don't start with a size.  Because of p2align and the
+    * end/END definitions, and the fact that they're mergeable, they can also
+    * have NULLs which aren't guaranteed to be at the end.
+    */
+   . = ALIGN(16);
+   __init_array_start = .;
+   *(SORT(.init_array.*))
+   *(.init_array)
+   __init_array_end = .;
+  . = ALIGN(16);
+   __CTOR_LIST__ = .;
+   *(SORT(.ctors.*))
+   *(.ctors)
+   __CTOR_END__ = .;
+  . = ALIGN(16);
+   __DTOR_LIST__ = .;
+   *(SORT(.dtors.*))
+   *(.dtors)
+   __DTOR_END__ = .;
+   . = ALIGN(16);
+   __fini_array_start = .;
+   *(SORT(.fini_array.*))
+   *(.fini_array)
+   __fini_array_end = .;
 
    /* the EFI loader doesn't seem to like a .bss section, so we stick
       it all into .data: */

--- a/efi/lds/elf_arm_efi.lds
+++ b/efi/lds/elf_arm_efi.lds
@@ -101,6 +101,17 @@ SECTIONS
   } =0
   _sbat_size = _epsbat - _sbat;
   _sbat_vsize = _esbat - _sbat;
+  . = ALIGN(4096);
+  .sbom :
+  {
+    _sbom = .;
+    *(.sbom)
+    _esbom = .;
+    . = ALIGN(4096);
+    _epsbom = .;
+  } =0
+  _sbom_size = _epsbom - _sbom;
+  _sbom_vsize = _esbom - _sbom;
   _image_end = .;
   _alldata_size = _image_end - _reloc;
 

--- a/efi/lds/elf_arm_efi.lds
+++ b/efi/lds/elf_arm_efi.lds
@@ -39,6 +39,33 @@ SECTIONS
    *(.data.*)
    *(.got.plt)
    *(.got)
+   
+   /*
+    * Note that these aren't the using the GNU "CONSTRUCTOR" output section
+    * command, so they don't start with a size.  Because of p2align and the
+    * end/END definitions, and the fact that they're mergeable, they can also
+    * have NULLs which aren't guaranteed to be at the end.
+    */
+   . = ALIGN(16);
+   __init_array_start = .;
+   *(SORT(.init_array.*))
+   *(.init_array)
+   __init_array_end = .;
+  . = ALIGN(16);
+   __CTOR_LIST__ = .;
+   *(SORT(.ctors.*))
+   *(.ctors)
+   __CTOR_END__ = .;
+  . = ALIGN(16);
+   __DTOR_LIST__ = .;
+   *(SORT(.dtors.*))
+   *(.dtors)
+   __DTOR_END__ = .;
+   . = ALIGN(16);
+   __fini_array_start = .;
+   *(SORT(.fini_array.*))
+   *(.fini_array)
+   __fini_array_end = .;
 
 
    /* the EFI loader doesn't seem to like a .bss section, so we stick

--- a/efi/lds/elf_ia32_efi.lds
+++ b/efi/lds/elf_ia32_efi.lds
@@ -31,6 +31,33 @@ SECTIONS
    *(.data)
    *(.data1)
    *(.data.*)
+   
+   /*
+    * Note that these aren't the using the GNU "CONSTRUCTOR" output section
+    * command, so they don't start with a size.  Because of p2align and the
+    * end/END definitions, and the fact that they're mergeable, they can also
+    * have NULLs which aren't guaranteed to be at the end.
+    */
+   . = ALIGN(16);
+   __init_array_start = .;
+   *(SORT(.init_array.*))
+   *(.init_array)
+   __init_array_end = .;
+  . = ALIGN(16);
+   __CTOR_LIST__ = .;
+   *(SORT(.ctors.*))
+   *(.ctors)
+   __CTOR_END__ = .;
+  . = ALIGN(16);
+   __DTOR_LIST__ = .;
+   *(SORT(.dtors.*))
+   *(.dtors)
+   __DTOR_END__ = .;
+   . = ALIGN(16);
+   __fini_array_start = .;
+   *(SORT(.fini_array.*))
+   *(.fini_array)
+   __fini_array_end = .;
 
    /* the EFI loader doesn't seem to like a .bss section, so we stick
       it all into .data: */

--- a/efi/lds/elf_ia32_efi.lds
+++ b/efi/lds/elf_ia32_efi.lds
@@ -81,6 +81,8 @@ SECTIONS
   _edata = .;
   _data_size = _edata - _etext;
   . = ALIGN(4096);
+  .sbom : { *(.sbom) }
+  . = ALIGN(4096);
   .reloc :		/* This is the PECOFF .reloc section! */
   {
     KEEP (*(.reloc))

--- a/efi/lds/elf_x86_64_efi.lds
+++ b/efi/lds/elf_x86_64_efi.lds
@@ -87,6 +87,8 @@ SECTIONS
   _sbat_size = _epsbat - _sbat;
   _sbat_vsize = _esbat - _sbat;
   . = ALIGN(4096);
+  .sbom : { *(.sbom) }
+  . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }
   . = ALIGN(4096);
   .dynstr   : { *(.dynstr) }

--- a/efi/lds/elf_x86_64_efi.lds
+++ b/efi/lds/elf_x86_64_efi.lds
@@ -38,6 +38,33 @@ SECTIONS
    *(.got)
    *(.data*)
    *(.sdata)
+   
+   /*
+    * Note that these aren't the using the GNU "CONSTRUCTOR" output section
+    * command, so they don't start with a size.  Because of p2align and the
+    * end/END definitions, and the fact that they're mergeable, they can also
+    * have NULLs which aren't guaranteed to be at the end.
+    */
+   . = ALIGN(16);
+   __init_array_start = .;
+   *(SORT(.init_array.*))
+   *(.init_array)
+   __init_array_end = .;
+  . = ALIGN(16);
+   __CTOR_LIST__ = .;
+   *(SORT(.ctors.*))
+   *(.ctors)
+   __CTOR_END__ = .;
+  . = ALIGN(16);
+   __DTOR_LIST__ = .;
+   *(SORT(.dtors.*))
+   *(.dtors)
+   __DTOR_END__ = .;
+   . = ALIGN(16);
+   __fini_array_start = .;
+   *(SORT(.fini_array.*))
+   *(.fini_array)
+   __fini_array_end = .;
 
    /* the EFI loader doesn't seem to like a .bss section, so we stick
       it all into .data: */

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -209,6 +209,16 @@ else
   efi_format = ['--target=efi-app-@0@'.format(gnu_efi_arch)]
 endif
 
+# Section data
+if objcopy_manualsymbols
+  nr_sections = 4
+  if get_option('efi_sbat_distro_id') != ''
+    compile_args += ['-DUSING_SBAT']
+    nr_sections = nr_sections + 1
+  endif
+  compile_args += ['-DNR_SECTIONS=@0@'.format(nr_sections)]
+endif
+
 libgcc_file_name = run_command(cc.cmd_array(), '-print-libgcc-file-name', check: true).stdout().strip()
 efi_name = 'fwupd@0@.efi'.format(EFI_MACHINE_TYPE_NAME)
 

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -102,7 +102,7 @@ endif
 
 # older objcopy for Aarch64 and ARM32 are not EFI capable.
 # Use 'binary' instead, and add required symbols manually.
-if host_cpu == 'arm' or (host_cpu == 'aarch64' and (objcopy_version.version_compare ('< 2.38') or coff_header_in_crt0))
+if host_cpu == 'arm' or (host_cpu == 'aarch64' and (objcopy_version.version_compare ('< 2.38') or coff_header_in_crt0 or uswid.found()))
   objcopy_manualsymbols = true
   generate_binary_extra = ['--objcopy-manualsymbols']
 else
@@ -121,6 +121,13 @@ if get_option('efi_sbat_distro_id') != ''
   endif
 endif
 
+# SBOM is never in system lds
+if uswid.found()
+  warning('Switching to local copy of linker script as using SBOM')
+  efi_ldsdir = join_paths(meson.current_source_dir(), 'lds')
+  arch_lds = 'elf_@0@@1@_efi.lds'.format(gnu_efi_arch, lds_os)
+endif
+
 # is the system crt0 for arm and aarch64 new enough to know about SBAT?
 if objcopy_manualsymbols
   if get_option('efi_sbat_distro_id') != ''
@@ -132,6 +139,15 @@ if objcopy_manualsymbols
       efi_crtdir = join_paths(meson.current_build_dir(), 'crt0')
       efi_ldsdir = join_paths(meson.current_source_dir(), 'lds')
     endif
+  endif
+endif
+
+# SBOM not in system crt0
+if objcopy_manualsymbols
+  if uswid.found()
+    warning('Switching to local copy of crt0 as using SBOM')
+    efi_crtdir = join_paths(meson.current_build_dir(), 'crt0')
+    efi_ldsdir = join_paths(meson.current_source_dir(), 'lds')
   endif
 endif
 

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -216,6 +216,10 @@ if objcopy_manualsymbols
     compile_args += ['-DUSING_SBAT']
     nr_sections = nr_sections + 1
   endif
+  if uswid.found()
+    compile_args += ['-DUSING_SBOM']
+    nr_sections = nr_sections + 1
+  endif
   compile_args += ['-DNR_SECTIONS=@0@'.format(nr_sections)]
 endif
 


### PR DESCRIPTION
- Make SBOM not break signing due to misplacement
- Add section to crt0
- prevent empty sections
