### PR TITLE
Use cflags with uswid

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -285,6 +285,11 @@ o_files += custom_target('fwup-sbat.o',
                         ])
 
 if uswid.found()
+  if uswid.version().version_compare('>=0.4.3')
+    uswid_cflags = ['--cflags', ' '.join(compile_args)]
+  else
+    uswid_cflags = []
+  endif
   o_files += custom_target('fwup-sbom.o',
                           output : 'fwup-sbom.o',
                           command : [
@@ -293,7 +298,7 @@ if uswid.found()
                             '--objcopy', objcopy,
                             '--load', swid_xml,
                             '--save', '@OUTPUT@',
-                          ])
+                          ] + uswid_cflags)
 endif
 
 fwupd_so_deps = []

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd-efi', 'c',
   version : '1.5',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.53.0',
+  meson_version : '>=0.62.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
Needs meson bump due to program.version() usage
although 0.62.0 is old at this point