### PR TITLE
add support for loongarch64

### DIFF
--- a/efi/crt0/crt0-efi-loongarch64.S
+++ b/efi/crt0/crt0-efi-loongarch64.S
@@ -1,0 +1,215 @@
+/*
+ * crt0-efi-loongarch64.S - PE/COFF header for LoongArch64 EFI applications
+ *
+ * Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice and this list of conditions, without modification.
+ * 2. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * Alternatively, this software may be distributed under the terms of the
+ * GNU General Public License as published by the Free Software Foundation;
+ * either version 2 of the License, or (at your option) any later version.
+ */
+
+	.section	.text.head
+
+	/*
+	 * Magic "MZ" signature for PE/COFF
+	 */
+	.globl	ImageBase
+ImageBase:
+	.ascii	"MZ"
+	.skip	58				// 'MZ' + pad + offset == 64
+	.4byte	pe_header - ImageBase		// Offset to the PE header.
+pe_header:
+	.ascii	"PE"
+	.2byte 	0
+coff_header:
+	.2byte	0x6264				// LoongArch64
+	.2byte	NR_SECTIONS		        // nr_sections
+	.4byte	0 				// TimeDateStamp
+	.4byte	0				// PointerToSymbolTable
+	.4byte	0				// NumberOfSymbols
+	.2byte	section_table - optional_header	// SizeOfOptionalHeader
+	.2byte	0x206				// Characteristics.
+						// IMAGE_FILE_DEBUG_STRIPPED |
+						// IMAGE_FILE_EXECUTABLE_IMAGE |
+						// IMAGE_FILE_LINE_NUMS_STRIPPED
+optional_header:
+	.2byte	0x20b				// PE32+ format
+	.byte	0x02				// MajorLinkerVersion
+	.byte	0x14				// MinorLinkerVersion
+	.4byte	_text_size - ImageBase		// SizeOfCode
+	.4byte	_alldata_size - ImageBase		// SizeOfInitializedData
+	.4byte	0				// SizeOfUninitializedData
+	.4byte	_start - ImageBase		// AddressOfEntryPoint
+	.4byte	_text - ImageBase		// BaseOfCode
+
+extra_header_fields:
+	.8byte	0				// ImageBase
+	.4byte	0x1000				// SectionAlignment
+	.4byte	0x1000				// FileAlignment
+	.2byte	0				// MajorOperatingSystemVersion
+	.2byte	0				// MinorOperatingSystemVersion
+	.2byte	0				// MajorImageVersion
+	.2byte	0				// MinorImageVersion
+	.2byte	0				// MajorSubsystemVersion
+	.2byte	0				// MinorSubsystemVersion
+	.4byte	0				// Win32VersionValue
+
+	.4byte	_image_end - ImageBase		// SizeOfImage
+
+	// Everything before the kernel image is considered part of the header
+	.4byte	_text - ImageBase		// SizeOfHeaders
+	.4byte	0				// CheckSum
+	.2byte	EFI_SUBSYSTEM			// Subsystem
+	.2byte	0				// DllCharacteristics
+	.8byte	0				// SizeOfStackReserve
+	.8byte	0				// SizeOfStackCommit
+	.8byte	0				// SizeOfHeapReserve
+	.8byte	0				// SizeOfHeapCommit
+	.4byte	0				// LoaderFlags
+	.4byte	0x10				// NumberOfRvaAndSizes
+
+	.8byte	0				// ExportTable
+	.8byte	0				// ImportTable
+	.8byte	0				// ResourceTable
+	.8byte	0				// ExceptionTable
+	.8byte	0				// CertificationTable
+	.4byte	_reloc - ImageBase				// BaseRelocationTable (VirtualAddress)
+	.4byte	_reloc_vsize - ImageBase				// BaseRelocationTable (Size)
+	.8byte	0				// Debug
+	.8byte	0				// Architecture
+	.8byte	0				// Global Ptr
+	.8byte	0				// TLS Table
+	.8byte	0				// Load Config Table
+	.8byte	0				// Bound Import
+	.8byte	0				// IAT
+	.8byte	0				// Delay Import Descriptor
+	.8byte	0				// CLR Runtime Header
+	.8byte	0				// Reserved, must be zero
+
+	// Section table
+section_table:
+
+	.ascii	".text\0\0\0"
+	.4byte	_text_vsize - ImageBase		// VirtualSize
+	.4byte	_text - ImageBase	// VirtualAddress
+	.4byte	_text_size - ImageBase		// SizeOfRawData
+	.4byte	_text - ImageBase	// PointerToRawData
+	.4byte	0		// PointerToRelocations (0 for executables)
+	.4byte	0		// PointerToLineNumbers (0 for executables)
+	.2byte	0		// NumberOfRelocations  (0 for executables)
+	.2byte	0		// NumberOfLineNumbers  (0 for executables)
+	.4byte	0x60000020	// Characteristics (section flags)
+
+	/*
+	 * The EFI application loader requires a relocation section
+	 * because EFI applications must be relocatable.  This is a
+	 * dummy section as far as we are concerned.
+	 */
+	.ascii	".reloc\0\0"
+	.4byte	_reloc_vsize - ImageBase			// VirtualSize
+	.4byte	_reloc - ImageBase			// VirtualAddress
+	.4byte	_reloc_size - ImageBase			// SizeOfRawData
+	.4byte	_reloc - ImageBase			// PointerToRawData
+	.4byte	0			// PointerToRelocations
+	.4byte	0			// PointerToLineNumbers
+	.2byte	0			// NumberOfRelocations
+	.2byte	0			// NumberOfLineNumbers
+	.4byte	0x42000040		// Characteristics (section flags)
+
+	.ascii	".data\0\0\0"
+	.4byte	_data_vsize - ImageBase			// VirtualSize
+	.4byte	_data - ImageBase			// VirtualAddress
+	.4byte	_data_size - ImageBase			// SizeOfRawData
+	.4byte	_data - ImageBase			// PointerToRawData
+	.4byte	0			// PointerToRelocations
+	.4byte	0			// PointerToLineNumbers
+	.2byte	0			// NumberOfRelocations
+	.2byte	0			// NumberOfLineNumbers
+	.4byte	0xC0000040		// Characteristics (section flags)
+
+	.ascii	".rodata\0"
+	.4byte	_rodata_vsize - ImageBase			// VirtualSize
+	.4byte	_rodata - ImageBase			// VirtualAddress
+	.4byte	_rodata_size - ImageBase			// SizeOfRawData
+	.4byte	_rodata - ImageBase			// PointerToRawData
+	.4byte	0			// PointerToRelocations
+	.4byte	0			// PointerToLineNumbers
+	.2byte	0			// NumberOfRelocations
+	.2byte	0			// NumberOfLineNumbers
+	.4byte	0x40000040		// Characteristics (section flags)
+
+#ifdef USING_SBAT
+	.ascii	".sbat\0\0\0"
+	.4byte	_sbat_vsize - ImageBase		// VirtualSize
+	.4byte	_sbat - ImageBase	// VirtualAddress
+	.4byte	_sbat_size - ImageBase		// SizeOfRawData
+	.4byte	_sbat - ImageBase	// PointerToRawData
+
+	.4byte	0		// PointerToRelocations (0 for executables)
+	.4byte	0		// PointerToLineNumbers (0 for executables)
+	.2byte	0		// NumberOfRelocations  (0 for executables)
+	.2byte	0		// NumberOfLineNumbers  (0 for executables)
+	.4byte	0x40000040	// Characteristics (section flags)
+#endif
+#ifdef USING_SBOM
+	.ascii	".sbom\0\0\0"
+	.4byte	_sbom_vsize - ImageBase		// VirtualSize
+	.4byte	_sbom - ImageBase	// VirtualAddress
+	.4byte	_sbom_size - ImageBase		// SizeOfRawData
+	.4byte	_sbom - ImageBase	// PointerToRawData
+
+	.4byte	0		// PointerToRelocations (0 for executables)
+	.4byte	0		// PointerToLineNumbers (0 for executables)
+	.2byte	0		// NumberOfRelocations  (0 for executables)
+	.2byte	0		// NumberOfLineNumbers  (0 for executables)
+	.4byte	0x40000040	// Characteristics (section flags)
+#endif
+
+	.text
+	.globl _start
+	.type _start,%function
+_start:
+	addi.d	  $sp, $sp, -24
+	st.d	  $ra, $sp, 0
+	st.d	  $a0, $sp, 8
+	st.d 	  $a1, $sp, 16
+
+	move	  $a2, $a0		// a2: ImageHandle
+	move	  $a3, $a1 		// a3: SystemTable
+	la.local  $a0, ImageBase	// a0: ImageBase
+	la.local  $a1, _DYNAMIC		// a1: DynamicSection
+	bl        _relocate
+	bnez	  $a0, 0f
+
+	ld.d	  $a0, $sp, 8
+	ld.d	  $a1, $sp, 16
+	bl 	  efi_main
+
+0:	ld.d	  $ra, $sp, 0
+	addi.d	  $sp, $sp, 24
+	jr        $ra
+	.end	  _start
+// hand-craft a dummy .reloc section so EFI knows it's a relocatable executable:
+
+ 	.data
+dummy:	.4byte	0
+
+#define IMAGE_REL_ABSOLUTE	0
+ 	.section .reloc, "a"
+label1:
+	.4byte	dummy-label1				// Page RVA
+	.4byte	12					// Block Size (2*4+2*2), must be aligned by 32 Bits
+	.2byte	(IMAGE_REL_ABSOLUTE<<12) +  0		// reloc for dummy
+	.2byte	(IMAGE_REL_ABSOLUTE<<12) +  0		// reloc for dummy
+
+#if defined(__ELF__) && defined(__linux__)
+	.section .note.GNU-stack,"",%progbits
+#endif

--- a/efi/lds/elf_loongarch64_efi.lds
+++ b/efi/lds/elf_loongarch64_efi.lds
@@ -1,0 +1,166 @@
+OUTPUT_FORMAT("elf64-loongarch", "elf64-loongarch", "elf64-loongarch")
+OUTPUT_ARCH(loongarch)
+ENTRY(_start)
+SECTIONS
+{
+  .text 0 : {
+    *(.text.head)
+    . = ALIGN(4096);
+    _text = .;
+    *(.text)
+    *(.text.*)
+    *(.gnu.linkonce.t.*)
+    *(.plt)
+    . = ALIGN(16);
+    _evtext = .;
+    . = ALIGN(4096);
+    _etext = .;
+  } =0
+  _text_vsize = _evtext - _text;
+  _text_size = _etext - _text;
+  . = ALIGN(4096);
+  _reloc = .;
+  .reloc : {
+    *(.reloc)
+    _evreloc = .;
+    . = ALIGN(4096);
+    _ereloc = .;
+  } =0
+  _reloc_vsize = _evreloc - _reloc;
+  _reloc_size = _ereloc - _reloc;
+  . = ALIGN(65536);
+  _data = .;
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .data :
+  {
+   *(.sdata)
+   *(.data)
+   *(.data1)
+   *(.data.*)
+   *(.got.plt)
+   *(.got)
+
+   /*
+    * Note that these aren't the using the GNU "CONSTRUCTOR" output section
+    * command, so they don't start with a size.  Because of p2align and the
+    * end/END definitions, and the fact that they're mergeable, they can also
+    * have NULLs which aren't guaranteed to be at the end.
+    */
+   . = ALIGN(16);
+   __init_array_start = .;
+   *(SORT(.init_array.*))
+   *(.init_array)
+   __init_array_end = .;
+  . = ALIGN(16);
+   __CTOR_LIST__ = .;
+   *(SORT(.ctors.*))
+   *(.ctors)
+   __CTOR_END__ = .;
+  . = ALIGN(16);
+   __DTOR_LIST__ = .;
+   *(SORT(.dtors.*))
+   *(.dtors)
+   __DTOR_END__ = .;
+   . = ALIGN(16);
+   __fini_array_start = .;
+   *(SORT(.fini_array.*))
+   *(.fini_array)
+   __fini_array_end = .;
+
+   /* the EFI loader doesn't seem to like a .bss section, so we stick
+      it all into .data: */
+   . = ALIGN(16);
+   _bss = .;
+   *(.sbss)
+   *(.scommon)
+   *(.dynbss)
+   *(.bss)
+   *(.bss.*)
+   *(COMMON)
+   . = ALIGN(16);
+   _bss_end = .;
+   _evdata = .;
+   . = ALIGN(4096);
+   _edata = .;
+  } =0
+  _data_vsize = _evdata - _data;
+  _data_size = _edata - _data;
+
+  . = ALIGN(4096);
+  _rodata = .;
+  .rela :
+  {
+    *(.rela.text*)
+    *(.rela.data*)
+    *(.rela.got)
+    *(.rela.dyn)
+    *(.rela.stab)
+
+  }
+  . = ALIGN(4096);
+  .rela.plt : { *(.rela.plt) }
+  . = ALIGN(4096);
+  .rodata : {
+    *(.rodata*)
+    _evrodata = .;
+    . = ALIGN(4096);
+    _erodata = .;
+  } =0
+  _rodata_vsize = _evrodata - _rodata;
+  _rodata_size = _erodata - _rodata;
+  /*
+   * Note that _sbat must be the beginning of the data, and _esbat must be the
+   * end and must be before any section padding.  The sbat self-check uses
+   * _esbat to find the bounds of the data, and if the padding is included, the
+   * CSV parser (correctly) rejects the data as having NUL values in one of the
+   * required columns.
+   */
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+    _esbat = .;
+    . = ALIGN(4096);
+    _epsbat = .;
+  } =0
+  _sbat_size = _epsbat - _sbat;
+  _sbat_vsize = _esbat - _sbat;
+  . = ALIGN(4096);
+  .sbom :
+  {
+    _sbom = .;
+    *(.sbom)
+    _esbom = .;
+    . = ALIGN(4096);
+    _epsbom = .;
+  } =0
+  _sbom_size = _epsbom - _sbom;
+  _sbom_vsize = _esbom - _sbom;
+  _image_end = .;
+  _alldata_size = _image_end - _reloc;
+
+  . = ALIGN(4096);
+  .dynsym   : { *(.dynsym) }
+  . = ALIGN(4096);
+  .dynstr   : { *(.dynstr) }
+  . = ALIGN(4096);
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+  . = ALIGN(4096);
+  .hash : { *(.hash) }
+  . = ALIGN(4096);
+  .gnu.hash : { *(.gnu.hash) }
+  . = ALIGN(4096);
+  .eh_frame : { *(.eh_frame) }
+  . = ALIGN(4096);
+  .gcc_except_table : { *(.gcc_except_table*) }
+  /DISCARD/ :
+  {
+    *(.rela.reloc)
+    *(.note.GNU-stack)
+  }
+  .comment 0 : { *(.comment) }
+}
+

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -105,6 +105,9 @@ endif
 if host_cpu == 'arm' or (host_cpu == 'aarch64' and (objcopy_version.version_compare ('< 2.38') or coff_header_in_crt0 or uswid.found()))
   objcopy_manualsymbols = true
   generate_binary_extra = ['--objcopy-manualsymbols']
+elif host_cpu == 'loongarch64' and (objcopy_version.version_compare ('< 2.41') or coff_header_in_crt0)
+  objcopy_manualsymbols = true
+  generate_binary_extra = ['--objcopy-manualsymbols']
 else
   objcopy_manualsymbols = false
   generate_binary_extra = []

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,9 @@ elif host_cpu == 'arm'
 elif host_cpu == 'aarch64'
         EFI_MACHINE_TYPE_NAME = 'aa64'
         gnu_efi_arch = 'aarch64'
+elif host_cpu == 'loongarch64'
+        EFI_MACHINE_TYPE_NAME = 'loongarch64'
+        gnu_efi_arch = 'loongarch64'
 else
         error('Unknown host_cpu ' + host_cpu)
 endif


### PR DESCRIPTION
Please review this patch, thank you.

I tested in qemu-system-loongarch64 using edk2 and got the following output:
```
Shell> fs0:\fwupdloongarch64.efi
fwupd-efi version 1.5
WARNING: No updates to process, exiting in 10 seconds.
Shell> 
```