### PR TITLE
Modify to use cc as ld (Since meson doesn't support calling LD)

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -311,11 +311,16 @@ if efi_crtdir == join_paths(meson.current_build_dir(), 'crt0')
   fwupd_so_deps += [o_crt0]
 endif
 
+efi_cc_ldflags = []
+foreach flag : efi_ldflags
+  efi_cc_ldflags += ['-Wl,' + flag]
+endforeach
+
 so = custom_target('fwup.so',
                    input : o_files,
                    output : 'fwup.so',
-                   command : [ld, '-o', '@OUTPUT@'] +
-                             efi_ldflags + ['@INPUT@'] +
+                   command : [cc.cmd_array(), '-nostdlib', '-o', '@OUTPUT@'] +
+                             efi_cc_ldflags + ['@INPUT@'] +
                              ['-lefi', '-lgnuefi', libgcc_file_name],
                    depends: fwupd_so_deps)
 

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ conf = configuration_data()
 conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 
 cc = meson.get_compiler('c')
-ld = cc.get_linker_id()
 objcopy = find_program('objcopy')
 objcopy_version = run_command(objcopy, '--version', check: true).stdout().split('\n')[0].split(' ')[-1]
 


### PR DESCRIPTION
With the help of another maintainer of Void @leahneukirchen we tried to understand the cross compilation issues.

We figured out that meson doesn't support calling LD. Because of that we changed the behavior and now CC will be used for LD. Now building and installing works without the variables efi_cc and efi_ld which got removed prior to version 1.4.

I didn't got the chance to try fwupd-efi fully with this changes. If you have some input about what could be some good tests please let me know. None of my systems have a update at the moment to test this.

This does fix https://github.com/fwupd/fwupd-efi/issues/39.