### PR TITLE
Explicitly set gnu-efi dependency for 3.0.18

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -45,12 +45,6 @@ if efi_libdir == ''
   endif
 endif
 
-have_gnu_efi = gnu_efi_path_arch != '' and efi_libdir != ''
-
-if not have_gnu_efi
-  error('gnu-efi support requested, but headers were not found')
-endif
-
 # The name we need to look for on this arch and OS: elf_x86_64_fbsd_efi.lds
 lds_os = ''
 if host_cpu == 'x86_64' and host_machine.system() == 'freebsd'
@@ -93,11 +87,6 @@ if run_command('grep', '-q', 'coff_header', join_paths(efi_crtdir, arch_crt), ch
         coff_header_in_crt0 = true
 else
         coff_header_in_crt0 = false
-endif
-
-# For NX compat, we must ensure we have .note.GNU-stack
-if run_command('grep', '-q', '.note.GNU-stack', join_paths(efi_crtdir, arch_crt), check: false).returncode() != 0
-  warning('Cannot find NX section in @0@, update to gnu-efi 3.0.15+'.format(join_paths(efi_crtdir, arch_crt)))
 endif
 
 # older objcopy for Aarch64, ARM32 and RISC-V are not EFI capable.

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ cc = meson.get_compiler('c')
 objcopy = find_program('objcopy')
 objcopy_version = run_command(objcopy, '--version', check: true).stdout().split('\n')[0].split(' ')[-1]
 
+gnuefi = dependency('gnu-efi', version: '>= 3.0.18')
 prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 libexecdir = join_paths(prefix, get_option('libexecdir'))


### PR DESCRIPTION
Two issues have been reported root caused by using gnu-efi 3.0.17 and fwupd-efi 1.5. They're fixed by upgrading to 3.0.18.

Link: https://github.com/fwupd/fwupd/issues/6976
Link: https://github.com/fwupd/fwupd/issues/6956

There are other optimizations to be done as well, but this is the most important one initially.