### PR TITLE
Disable RELRO

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -206,6 +206,7 @@ efi_ldflags = ['-T',
                '-Bsymbolic',
                '-nostdlib',
                '-znocombreloc',
+               '-znorelro',
                '-L', efi_crtdir,
                '-L', efi_libdir,
                join_paths(efi_crtdir, arch_crt)]


### PR DESCRIPTION
No point having PT_GNU_RELRO as ELF data won't exist when merging into PE32+ file

Unbreaks lld usage which complains about linker script
Copy of ncroxon/gnu-efi#5