### PR TITLE
Fix python3 shebang paths and add python option.

### DIFF
--- a/contrib/reformat-code.py
+++ b/contrib/reformat-code.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Dell Inc.
 #

--- a/efi/generate_binary.py
+++ b/efi/generate_binary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2021 Javier Martinez Canillas <javierm@redhat.com>
 # Copyright (C) 2021 Richard Hughes <richard@hughsie.com>

--- a/efi/generate_sbat.py
+++ b/efi/generate_sbat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2021 Javier Martinez Canillas <javierm@redhat.com>
 # Copyright (C) 2021 Richard Hughes <richard@hughsie.com>

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -1,5 +1,5 @@
-generate_sbat = find_program('generate_sbat.py', native: true)
-generate_binary = find_program('generate_binary.py', native: true)
+generate_sbat = [python3, files('generate_sbat.py')]
+generate_binary = [python3, files('generate_binary.py')]
 
 # get source version, falling back
 git = find_program('git', required : false)

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,13 @@ libexecdir = join_paths(prefix, get_option('libexecdir'))
 
 genpeimg = find_program ('genpeimg', required: get_option('genpeimg'))
 
+python3path = get_option('python')
+if python3path == ''
+  python3 = import('python').find_installation('python3')
+else
+  python3 = find_program(python3path)
+endif
+
 efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
 host_cpu = host_machine.cpu_family()
 if host_cpu == 'x86'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('efi_sbat_distro_pkgname', type : 'string', value : '', description : 'SB
 option('efi_sbat_distro_version', type : 'string', value : '', description : 'SBAT distribution version, e.g. fwupd-1.5.6.fc33')
 option('efi_sbat_distro_url', type : 'string', value : '', description : 'SBAT distribution URL, e.g. https://src.fedoraproject.org/rpms/fwupd')
 option('genpeimg', type : 'feature', description : 'Use genpeimg to add NX support to binaries')
+option('python', type : 'string', description : 'the absolute path of the python3 binary')


### PR DESCRIPTION
Using absolute paths can result in the wrong python3 binary being used, such as when cross compiling using a non-system python3.

Use the normal python3 env shebang instead.

Also add a meson option to allow overriding the python path.