### PR TITLE
Allow enabling/disabling the use of genpeimg binary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@ prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 libexecdir = join_paths(prefix, get_option('libexecdir'))
 
-genpeimg = find_program ('genpeimg', required: false)
+genpeimg = find_program ('genpeimg', required: get_option('genpeimg'))
 
 efi_app_location = join_paths(libexecdir, 'fwupd', 'efi')
 host_cpu = host_machine.cpu_family()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,4 @@ option('efi_sbat_distro_summary', type : 'string', value : '', description : 'SB
 option('efi_sbat_distro_pkgname', type : 'string', value : '', description : 'SBAT distribution package name, e.g. fwupd')
 option('efi_sbat_distro_version', type : 'string', value : '', description : 'SBAT distribution version, e.g. fwupd-1.5.6.fc33')
 option('efi_sbat_distro_url', type : 'string', value : '', description : 'SBAT distribution URL, e.g. https://src.fedoraproject.org/rpms/fwupd')
+option('genpeimg', type : 'feature', description : 'Use genpeimg to add NX support to binaries')


### PR DESCRIPTION
In some cases we may want to force the use of python3-pefile instead of genpeimg such as when cross compiling, add a feature option to allow disabling genpeimg.