### PR TITLE
Disable genpeimg in fedora spec

### DIFF
--- a/contrib/fwupd-efi.spec.in
+++ b/contrib/fwupd-efi.spec.in
@@ -37,7 +37,8 @@ the EFI binary that is used for updating using UpdateCapsule.
     -Defi_sbat_distro_summary="The Fedora Project" \
     -Defi_sbat_distro_pkgname="%{name}" \
     -Defi_sbat_distro_version="%{version}-%{release}" \
-    -Defi_sbat_distro_url="https://src.fedoraproject.org/rpms/%{name}"
+    -Defi_sbat_distro_url="https://src.fedoraproject.org/rpms/%{name}" \
+    -Dgenpeimg=disabled
 
 %meson_build
 


### PR DESCRIPTION
Fedora seems to pass --auto-features=enabled to meson which enables any features that aren't explicitely disabled. As such we need to disable genpeimg since fedora uses python3-pefile instead.