### PR TITLE
Support GNU-EFI 4.0

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -232,6 +232,13 @@ endif
 libgcc_file_name = run_command(cc.cmd_array(), '-print-libgcc-file-name', check: true).stdout().strip()
 efi_name = 'fwupd@0@.efi'.format(EFI_MACHINE_TYPE_NAME)
 
+# GNU-EFI 4.0 changed how CompareGuid works (to align with EDK2)
+# Keep GNU-EFI 3.0 support for a while
+if gnuefi.version().version_compare('>=4.0.0')
+  compile_args += ['-DGNU_EFI_3_0_COMPAT']
+endif
+
+
 o_files = []
 o_files += custom_target('fwupdate.o',
                         input : 'fwupdate.c',


### PR DESCRIPTION
* Set GNU_EFI_3_0_COMPAT so CompareGuid runs using the old version otherwise this will break

Changed made in ncroxon/gnu-efi@a093fe03786b15ecabaa0d16f84c8133f76ca0c0