### PR TITLE
Add support for .pkgnote

### DIFF
--- a/contrib/fwupd-efi.spec.in
+++ b/contrib/fwupd-efi.spec.in
@@ -38,6 +38,11 @@ the EFI binary that is used for updating using UpdateCapsule.
     -Defi_sbat_distro_pkgname="%{name}" \
     -Defi_sbat_distro_version="%{version}-%{release}" \
     -Defi_sbat_distro_url="https://src.fedoraproject.org/rpms/%{name}" \
+    -Dpkgnote="{\"type\":\"rpm\", \
+                \"name\":\"%{name}\", \
+                \"version\":\"%{version}-%{release}\", \
+                \"architecture\":\"%{_arch}\", \
+                \"osCpe\":\"cpe:/o:fwupd:fwupd-efi\"}" \
     -Dgenpeimg=disabled
 
 %meson_build

--- a/efi/generate_binary.py
+++ b/efi/generate_binary.py
@@ -10,6 +10,8 @@
 import subprocess
 import sys
 import argparse
+import tempfile
+import json
 
 
 def _run_objcopy(args):
@@ -68,6 +70,33 @@ def _run_genpeimg(args):
         sys.exit(1)
 
 
+def _run_pkgnote(args):
+
+    if not args.pkgnote:
+        return
+
+    # verify this is actually JSON
+    try:
+        _ = json.loads(args.pkgnote)
+    except json.JSONDecodeError as e:
+        print(f"Not valid JSON: {e}")
+        sys.exit(1)
+
+    # use `objdump -s -j .pkgnote` to verify
+    with tempfile.NamedTemporaryFile() as sfd:
+        sfd.write(args.pkgnote.encode() + b"\0")
+        sfd.flush()
+        argv = [
+            args.objcopy,
+            "--add-section",
+            ".pkgnote={}".format(sfd.name),
+            "--set-section-flags",
+            ".sbat=contents,alloc,load,readonly,data",
+            args.outfile,
+        ]
+        subprocess.run(argv, check=True)
+
+
 def _add_nx_pefile(args):
     # unnecessary if we have genpeimg
     if args.genpeimg:
@@ -92,6 +121,7 @@ if __name__ == "__main__":
         "--objcopy", default="objcopy", help="Binary file to use for objcopy"
     )
     parser.add_argument("--genpeimg", help="Binary file to use for genpeimg")
+    parser.add_argument("--pkgnote", help="Package metadata in JSON format")
     parser.add_argument("--arch", default="x86_64", help="EFI architecture")
     parser.add_argument("--os", help="OS type")
     parser.add_argument(
@@ -103,6 +133,7 @@ if __name__ == "__main__":
     parser.add_argument("outfile", help="Output file")
     _args = parser.parse_args()
     _run_objcopy(_args)
+    _run_pkgnote(_args)
     _run_genpeimg(_args)
     _add_nx_pefile(_args)
 

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -327,6 +327,7 @@ app = custom_target(efi_name,
                       '--arch', gnu_efi_arch,
                       '--os', host_machine.system(),
                       '--objcopy', objcopy,
+                      '--pkgnote', get_option('pkgnote'),
                       '--genpeimg', genpeimg.found() ? genpeimg : ''
                     ]
                     + generate_binary_extra,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,5 +7,6 @@ option('efi_sbat_distro_summary', type : 'string', value : '', description : 'SB
 option('efi_sbat_distro_pkgname', type : 'string', value : '', description : 'SBAT distribution package name, e.g. fwupd')
 option('efi_sbat_distro_version', type : 'string', value : '', description : 'SBAT distribution version, e.g. fwupd-1.5.6.fc33')
 option('efi_sbat_distro_url', type : 'string', value : '', description : 'SBAT distribution URL, e.g. https://src.fedoraproject.org/rpms/fwupd')
+option('pkgnote', type : 'string', value : '', description : 'Package metadata in JSON format')
 option('genpeimg', type : 'feature', description : 'Use genpeimg to add NX support to binaries')
 option('python', type : 'string', description : 'the absolute path of the python3 binary')


### PR DESCRIPTION
	$ objdump -s -j .pkgnote /usr/libexec/fwupd/efi/fwupdx64.efi

	/usr/libexec/fwupd/efi/fwupdx64.efi:     file format pei-x86-64

	Contents of section .pkgnote:
	 0000 7b227479 7065223a 2272706d 222c2020  {"type":"rpm",
	 0010 20202020 20202020 20202020 20202022                 "
	 0020 6e616d65 223a2266 77757064 2d656669  name":"fwupd-efi
	 0030 222c2020 20202020 20202020 20202020  ",
	 0040 20202022 76657273 696f6e22 3a22312e     "version":"1.
	 0050 382d302e 32392e32 30323530 31313667  8-0.29.20250116g
	 0060 69742e66 63343122 2c202020 20202020  it.fc41",
	 0070 20202020 20202020 20202261 72636869            "archi
	 0080 74656374 75726522 3a227838 365f3634  tecture":"x86_64
	 0090 222c2020 20202020 20202020 20202020  ",
	 00a0 20202022 6f734370 65223a22 6370653a     "osCpe":"cpe:
	 00b0 2f6f3a66 77757064 3a667775 70642d65  /o:fwupd:fwupd-e
	 00c0 6669227d 00                          fi"}.

See https://github.com/systemd/systemd/pull/35681