### PR TITLE
EFI target handling for RISC-V (as of objcopy 2.42)

### DIFF
--- a/efi/meson.build
+++ b/efi/meson.build
@@ -91,10 +91,10 @@ endif
 
 # older objcopy for Aarch64, ARM32 and RISC-V are not EFI capable.
 # Use 'binary' instead, and add required symbols manually.
-if host_cpu == 'arm' or host_cpu == 'riscv64' or (host_cpu == 'aarch64' and (objcopy_version.version_compare ('< 2.38') or coff_header_in_crt0 or uswid.found()))
-  objcopy_manualsymbols = true
-  generate_binary_extra = ['--objcopy-manualsymbols']
-elif host_cpu == 'loongarch64' and (objcopy_version.version_compare ('< 2.41') or coff_header_in_crt0)
+if ( host_cpu == 'arm'
+  or (host_cpu == 'riscv64'     and (objcopy_version.version_compare ('< 2.42') or coff_header_in_crt0))
+  or (host_cpu == 'aarch64'     and (objcopy_version.version_compare ('< 2.38') or coff_header_in_crt0 or uswid.found()))
+  or (host_cpu == 'loongarch64' and (objcopy_version.version_compare ('< 2.41') or coff_header_in_crt0)) )
   objcopy_manualsymbols = true
   generate_binary_extra = ['--objcopy-manualsymbols']
 else


### PR DESCRIPTION
fix https://github.com/fwupd/fwupd-efi/issues/151

Support for `efi-app-riscv64` has been added to `objcopy` in version 2.42:
``` 
Handle "efi-app-riscv64" and similar targets in objcopy.
This adds the efi target name handling for riscv64 to objcopy.

binutils:
* binutils/objcopy.c: add riscv64 handling to
		convert_efi_target()
```
(binutils-2.42/ChangeLog.git)