### PR TITLE
Use --output-target to define the object's output format

### DIFF
--- a/efi/generate_binary.py
+++ b/efi/generate_binary.py
@@ -42,12 +42,8 @@ def _run_objcopy(args):
     # Use "binary" instead, and add required symbols manually.
     if args.objcopy_manualsymbols:
         argv.extend(["-O", "binary"])
-    elif args.os == "freebsd":
-        # `--target` option is missing and --input-target doesn't recognize
-        # "efi-app-*"
-        argv.extend(["--output-target", "efi-app-{}".format(args.arch)])
     else:
-        argv.extend(["--target", "efi-app-{}".format(args.arch)])
+        argv.extend(["--output-target", "efi-app-{}".format(args.arch)])
 
     try:
         subprocess.run(argv, check=True)

--- a/efi/meson.build
+++ b/efi/meson.build
@@ -229,7 +229,7 @@ if objcopy_manualsymbols
   endif
   efi_format = ['-O', 'binary']
 else
-  efi_format = ['--target=efi-app-@0@'.format(gnu_efi_arch)]
+  efi_format = ['--output-target=efi-app-@0@'.format(gnu_efi_arch)]
 endif
 
 libgcc_file_name = run_command(cc.cmd_array(), '-print-libgcc-file-name', check: true).stdout().strip()


### PR DESCRIPTION
A recent binutils post version 2.45 change [0] made more strict the usage of objcopy's target options. In prior versions, the --target option could be used to specify either an input or output binary object target.

But now, users must use --input-target or --output-target if the input and output object format differs. The --target option shall only be used when both input and output formats are the same.

Not doing that, leads to objcopy complaining that the file format is not recognized:

    /usr/bin/objcopy: efi/fwup.so: file format not recognized

[0]: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=5e83077d552e