### PR TITLE
trivial: Lower supported meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd-efi', 'c',
   version : '1.9',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.62.0',
+  meson_version : '>=0.58.2',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
We don't actually need any newer version...